### PR TITLE
Include support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,16 @@
           </archive>
         </configuration>
       </plugin>
+
+<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.5</source>
+        </configuration>
+      </plugin>
+
 </plugins>
 </build>
     <scm>

--- a/src/main/java/hu/everit/utils/xsd/downloader/XsdDownloader.java
+++ b/src/main/java/hu/everit/utils/xsd/downloader/XsdDownloader.java
@@ -173,7 +173,6 @@ public class XsdDownloader
                 {
                     System.out.println("WSDL Found");
                     String schLoc = childElement.getAttribute("location");
-					System.out.println("Schema needed " + schLoc);
 
                     if (!fileNamesByprocessedUrls.containsKey(schLoc))
                     {

--- a/src/main/java/hu/everit/utils/xsd/downloader/XsdDownloader.java
+++ b/src/main/java/hu/everit/utils/xsd/downloader/XsdDownloader.java
@@ -120,6 +120,8 @@ public class XsdDownloader
         outputFileName = outputFileName + ".xsd";
         fileNamesByprocessedUrls.put(xsdUrl, outputFileName);
 
+		System.out.println("Download " + xsdUrl);
+
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
         DocumentBuilder db = dbf.newDocumentBuilder();
@@ -146,10 +148,11 @@ public class XsdDownloader
             {
                 Element childElement = (Element) childNode;
                 if ("http://www.w3.org/2001/XMLSchema".equals(childElement.getNamespaceURI())
-                    && childElement.getLocalName().equals("import"))
+                    && (childElement.getLocalName().equals("import") || childElement.getLocalName().equals("include")))
                 {
                     System.out.println("New Element Found");
                     String schLoc = childElement.getAttribute("schemaLocation");
+
                     if (!fileNamesByprocessedUrls.containsKey(schLoc))
                     {
                         downloadXsdRecurse(schLoc);
@@ -166,10 +169,12 @@ public class XsdDownloader
                     }
                 }
                 else if ("http://schemas.xmlsoap.org/wsdl/".equals(childElement.getNamespaceURI())
-                         && childElement.getLocalName().equals("import"))
+                         && (childElement.getLocalName().equals("import") || childElement.getLocalName().equals("include")))
                 {
                     System.out.println("WSDL Found");
                     String schLoc = childElement.getAttribute("location");
+					System.out.println("Schema needed " + schLoc);
+
                     if (!fileNamesByprocessedUrls.containsKey(schLoc))
                     {
                         downloadXsdRecurse(schLoc);


### PR DESCRIPTION
Hi!

This is a very handy tool for WS developer to deal with broken or bad designred webservices, but I've tried to download some really complex WSDLs using this tool and found that it downloads only imported XSDs but not included XSDs.

This patch allows to download them too.
I've also added debug printing of download URLs so one can see what's exactly being downloaded.
